### PR TITLE
grpc_stats: add config to replace dots in gprc service_name before eitting metrics

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_stats/v3/config.proto
+++ b/api/envoy/extensions/filters/http/grpc_stats/v3/config.proto
@@ -19,6 +19,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.http.grpc_stats]
 
 // gRPC statistics filter configuration
+// [#next-free-field: 6]
 message FilterConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.grpc_stats.v2alpha.FilterConfig";
@@ -59,6 +60,10 @@ message FilterConfig {
   // <envoy_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.individual_method_stats_allowlist>` the same way
   // request_message_count and response_message_count works.
   bool enable_upstream_stats = 4;
+
+  // if true, the filter will replace dots in the grpc_service_name before emitting the metrics.
+  // By default it is set as false.
+  bool replace_dots_in_grpc_service_name = 5;
 }
 
 // gRPC statistics filter state object in protobuf form.

--- a/api/envoy/extensions/filters/http/grpc_stats/v3/config.proto
+++ b/api/envoy/extensions/filters/http/grpc_stats/v3/config.proto
@@ -61,8 +61,10 @@ message FilterConfig {
   // request_message_count and response_message_count works.
   bool enable_upstream_stats = 4;
 
-  // if true, the filter will replace dots in the grpc_service_name before emitting the metrics.
-  // By default it is set as false.
+  // If true, the filter will replace dots in the grpc_service_name before emitting the metrics.
+  // Only works when :ref:`stats_for_all_methods
+  // <envoy_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.stats_for_all_methods>`
+  // is set to true. By default it is set as false.
   bool replace_dots_in_grpc_service_name = 5;
 }
 

--- a/generated_api_shadow/envoy/extensions/filters/http/grpc_stats/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/grpc_stats/v3/config.proto
@@ -19,6 +19,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.http.grpc_stats]
 
 // gRPC statistics filter configuration
+// [#next-free-field: 6]
 message FilterConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.grpc_stats.v2alpha.FilterConfig";
@@ -59,6 +60,10 @@ message FilterConfig {
   // <envoy_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.individual_method_stats_allowlist>` the same way
   // request_message_count and response_message_count works.
   bool enable_upstream_stats = 4;
+
+  // if true, the filter will replace dots in the grpc_service_name before emitting the metrics.
+  // By default it is set as false.
+  bool replace_dots_in_grpc_service_name = 5;
 }
 
 // gRPC statistics filter state object in protobuf form.

--- a/generated_api_shadow/envoy/extensions/filters/http/grpc_stats/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/grpc_stats/v3/config.proto
@@ -61,8 +61,10 @@ message FilterConfig {
   // request_message_count and response_message_count works.
   bool enable_upstream_stats = 4;
 
-  // if true, the filter will replace dots in the grpc_service_name before emitting the metrics.
-  // By default it is set as false.
+  // If true, the filter will replace dots in the grpc_service_name before emitting the metrics.
+  // Only works when :ref:`stats_for_all_methods
+  // <envoy_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.stats_for_all_methods>`
+  // is set to true. By default it is set as false.
   bool replace_dots_in_grpc_service_name = 5;
 }
 

--- a/include/envoy/grpc/context.h
+++ b/include/envoy/grpc/context.h
@@ -35,6 +35,19 @@ public:
   resolveDynamicServiceAndMethod(const Http::HeaderEntry* path) PURE;
 
   /**
+   * Parses out request grpc service-name and method from the path, returning a
+   * populated RequestStatNames if successful. See the implementation
+   * (source/common/grpc/common.h) for the definition of RequestStatNames. It is
+   * hidden in the implementation since it references StatName, which is defined
+   * only in the stats implementation.
+   *
+   * @param path the request path.
+   * @return the request names, expressed as StatName.
+   */
+  virtual std::pair<absl::optional<RequestStatNames>, std::unique_ptr<std::string>>
+  resolveDynamicServiceAndMethodWithDotReplaced(const Http::HeaderEntry* path) PURE;
+
+  /**
    * Charge a success/failure stat to a cluster/service/method.
    * @param cluster supplies the target cluster.
    * @param protocol supplies the downstream protocol in use.

--- a/include/envoy/grpc/context.h
+++ b/include/envoy/grpc/context.h
@@ -35,14 +35,16 @@ public:
   resolveDynamicServiceAndMethod(const Http::HeaderEntry* path) PURE;
 
   /**
-   * Parses out request grpc service-name and method from the path, returning a
-   * populated RequestStatNames if successful. See the implementation
-   * (source/common/grpc/common.h) for the definition of RequestStatNames. It is
-   * hidden in the implementation since it references StatName, which is defined
-   * only in the stats implementation.
+   * Parses out request grpc service-name and method from the path with dots
+   * replaced by underscores in grpc service-name, returning a populated
+   * RequestStatName and the grpc service-name without dots if successful. See
+   * the implementation (source/common/grpc/common.h) for the definition of
+   * RequestStatNames. It is hidden in the implementation since it references StatName, which is
+   * defined only in the stats implementation.
    *
    * @param path the request path.
-   * @return the request names, expressed as StatName.
+   * @return a pair containing request names expressed StatName and a unique_ptr
+   * to the grpc service name with dots replaced.
    */
   virtual std::pair<absl::optional<RequestStatNames>, std::unique_ptr<std::string>>
   resolveDynamicServiceAndMethodWithDotReplaced(const Http::HeaderEntry* path) PURE;

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -77,7 +77,7 @@ TagNameValues::TagNameValues() {
   addTokenized(MONGO_CMD, "mongo.*.cmd.$.**");
 
   // cluster.[<route_target_cluster>.]grpc.[<grpc_service>.](<grpc_method>.)*
-  addTokenized(GRPC_BRIDGE_METHOD, "cluster.*.grpc.*.$.**");
+  addRe2(GRPC_BRIDGE_METHOD, R"(^cluster\.<NAME>\.grpc\.<NAME>\.((<NAME>)\.))", ".grpc.");
 
   // http.[<stat_prefix>.]user_agent.(<user_agent>.)*
   addTokenized(HTTP_USER_AGENT, "http.*.user_agent.$.**");
@@ -95,7 +95,7 @@ TagNameValues::TagNameValues() {
   addRe2(SSL_CIPHER_SUITE, R"(^cluster\.<NAME>\.ssl\.ciphers(\.(<CIPHER>))$)", ".ssl.ciphers.");
 
   // cluster.[<route_target_cluster>.]grpc.(<grpc_service>.)*
-  addTokenized(GRPC_BRIDGE_SERVICE, "cluster.*.grpc.$.**");
+  addRe2(GRPC_BRIDGE_SERVICE, R"(^cluster\.<NAME>\.grpc\.((<NAME>)\.))", ".grpc.");
 
   // tcp.(<stat_prefix>.)*
   addTokenized(TCP_PREFIX, "tcp.$.**");

--- a/source/common/grpc/context_impl.cc
+++ b/source/common/grpc/context_impl.cc
@@ -1,10 +1,15 @@
 #include "common/grpc/context_impl.h"
 
 #include <cstdint>
+#include <memory>
 #include <string>
+#include <tuple>
+#include <utility>
 
 #include "common/grpc/common.h"
 #include "common/stats/utility.h"
+
+#include "absl/strings/str_replace.h"
 
 namespace Envoy {
 namespace Grpc {
@@ -92,6 +97,19 @@ ContextImpl::resolveDynamicServiceAndMethod(const Http::HeaderEntry* path) {
   Stats::Element service = Stats::DynamicName(request_names->service_);
   Stats::Element method = Stats::DynamicName(request_names->method_);
   return RequestStatNames{service, method};
+}
+
+std::pair<absl::optional<ContextImpl::RequestStatNames>, std::unique_ptr<std::string>>
+ContextImpl::resolveDynamicServiceAndMethodWithDotReplaced(const Http::HeaderEntry* path) {
+  absl::optional<Common::RequestNames> request_names = Common::resolveServiceAndMethod(path);
+  if (!request_names) {
+    return {};
+  }
+  auto service_name =
+      std::make_unique<std::string>(absl::StrReplaceAll(request_names->service_, {{".", "_"}}));
+  Stats::Element service = Stats::DynamicName(*service_name);
+  Stats::Element method = Stats::DynamicName(request_names->method_);
+  return std::make_pair(RequestStatNames{service, method}, std::move(service_name));
 }
 
 } // namespace Grpc

--- a/source/common/grpc/context_impl.h
+++ b/source/common/grpc/context_impl.h
@@ -54,10 +54,11 @@ public:
   resolveDynamicServiceAndMethod(const Http::HeaderEntry* path) override;
 
   /**
-   * Resolve the gRPC service and method from the HTTP2 :path header.
+   * Resolve the gRPC service and method from the HTTP2 :path header. Replace dots in the gRPC
+   * service name if there are any.
    * @param path supplies the :path header.
    * @return if both gRPC serve and method have been resolved successfully returns
-   *   a populated RequestStatNames, otherwise returns an empty optional.
+   *   a populated RequestStatNames and an unique_ptr, otherwise returns an empty optional.
    */
   std::pair<absl::optional<RequestStatNames>, std::unique_ptr<std::string>>
   resolveDynamicServiceAndMethodWithDotReplaced(const Http::HeaderEntry* path) override;

--- a/source/common/grpc/context_impl.h
+++ b/source/common/grpc/context_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "envoy/grpc/context.h"
@@ -51,6 +52,15 @@ public:
    */
   absl::optional<RequestStatNames>
   resolveDynamicServiceAndMethod(const Http::HeaderEntry* path) override;
+
+  /**
+   * Resolve the gRPC service and method from the HTTP2 :path header.
+   * @param path supplies the :path header.
+   * @return if both gRPC serve and method have been resolved successfully returns
+   *   a populated RequestStatNames, otherwise returns an empty optional.
+   */
+  std::pair<absl::optional<RequestStatNames>, std::unique_ptr<std::string>>
+  resolveDynamicServiceAndMethodWithDotReplaced(const Http::HeaderEntry* path) override;
 
   Stats::StatName successStatName(bool success) const { return success ? success_ : failure_; }
   Stats::StatName protocolStatName(Protocol protocol) const {

--- a/test/common/grpc/context_impl_test.cc
+++ b/test/common/grpc/context_impl_test.cc
@@ -87,5 +87,30 @@ TEST(GrpcContextTest, ResolveServiceAndMethod) {
   EXPECT_FALSE(context.resolveDynamicServiceAndMethod(path));
 }
 
+TEST(GrpcContextTest, resolveDynamicServiceAndMethodWithDotReplaced) {
+  Http::TestRequestHeaderMapImpl headers;
+  headers.setPath("/foo.bar.zoo/method.name?a=b");
+  const Http::HeaderEntry* path = headers.Path();
+  Stats::TestUtil::TestSymbolTable symbol_table;
+  ContextImpl context(*symbol_table);
+  absl::optional<Context::RequestStatNames> request_names;
+  std::unique_ptr<std::string> service_name_without_dots_;
+  std::tie(request_names, service_name_without_dots_) =
+      context.resolveDynamicServiceAndMethodWithDotReplaced(path);
+  EXPECT_TRUE(request_names);
+  EXPECT_EQ("foo_bar_zoo", absl::get<Stats::DynamicName>(request_names->service_));
+  EXPECT_EQ("method.name", absl::get<Stats::DynamicName>(request_names->method_));
+  headers.setPath("");
+  EXPECT_FALSE(context.resolveDynamicServiceAndMethodWithDotReplaced(path).first);
+  headers.setPath("/");
+  EXPECT_FALSE(context.resolveDynamicServiceAndMethodWithDotReplaced(path).first);
+  headers.setPath("//");
+  EXPECT_FALSE(context.resolveDynamicServiceAndMethodWithDotReplaced(path).first);
+  headers.setPath("/service_name");
+  EXPECT_FALSE(context.resolveDynamicServiceAndMethodWithDotReplaced(path).first);
+  headers.setPath("/service_name/");
+  EXPECT_FALSE(context.resolveDynamicServiceAndMethodWithDotReplaced(path).first);
+}
+
 } // namespace Grpc
 } // namespace Envoy

--- a/test/extensions/filters/http/grpc_stats/config_test.cc
+++ b/test/extensions/filters/http/grpc_stats/config_test.cc
@@ -72,6 +72,7 @@ protected:
 
 TEST_F(GrpcStatsFilterConfigTest, StatsHttp2HeaderOnlyResponse) {
   config_.mutable_stats_for_all_methods()->set_value(true);
+  config_.set_replace_dots_in_grpc_service_name(true);
   initialize();
   Http::TestRequestHeaderMapImpl request_headers{
       {"content-type", "application/grpc"},
@@ -95,11 +96,20 @@ TEST_F(GrpcStatsFilterConfigTest, StatsHttp2HeaderOnlyResponse) {
                      ->statsScope()
                      .counterFromString("grpc.lyft.users.BadCompanions.GetBadCompanions.total")
                      .value());
+  EXPECT_EQ(1UL, decoder_callbacks_.clusterInfo()
+                     ->statsScope()
+                     .counterFromString("grpc.lyft_users_BadCompanions.GetBadCompanions.failure")
+                     .value());
+  EXPECT_EQ(1UL, decoder_callbacks_.clusterInfo()
+                     ->statsScope()
+                     .counterFromString("grpc.lyft_users_BadCompanions.GetBadCompanions.total")
+                     .value());
   EXPECT_FALSE(stream_info_.filterState()->hasDataWithName(HttpFilterNames::get().GrpcStats));
 }
 
 TEST_F(GrpcStatsFilterConfigTest, StatsHttp2NormalResponse) {
   config_.mutable_stats_for_all_methods()->set_value(true);
+  config_.set_replace_dots_in_grpc_service_name(true);
   initialize();
   Http::TestRequestHeaderMapImpl request_headers{
       {"content-type", "application/grpc"},
@@ -114,6 +124,14 @@ TEST_F(GrpcStatsFilterConfigTest, StatsHttp2NormalResponse) {
   EXPECT_EQ(1UL, decoder_callbacks_.clusterInfo()
                      ->statsScope()
                      .counterFromString("grpc.lyft.users.BadCompanions.GetBadCompanions.total")
+                     .value());
+  EXPECT_EQ(1UL, decoder_callbacks_.clusterInfo()
+                     ->statsScope()
+                     .counterFromString("grpc.lyft_users_BadCompanions.GetBadCompanions.success")
+                     .value());
+  EXPECT_EQ(1UL, decoder_callbacks_.clusterInfo()
+                     ->statsScope()
+                     .counterFromString("grpc.lyft_users_BadCompanions.GetBadCompanions.total")
                      .value());
   EXPECT_FALSE(stream_info_.filterState()->hasDataWithName(HttpFilterNames::get().GrpcStats));
 }


### PR DESCRIPTION

Signed-off-by: junpengl <ljpeng1001@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
