### PR TITLE
grpc_stats: revert the GRPC_BRIDGE_METHOD Regex to v1.13

### DIFF
--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -76,8 +76,8 @@ TagNameValues::TagNameValues() {
   // mongo.[<stat_prefix>.]cmd.(<cmd>.)*
   addTokenized(MONGO_CMD, "mongo.*.cmd.$.**");
 
-  // cluster.[<route_target_cluster>.]grpc.[<grpc_service>.](<grpc_method>.)*
-  addRe2(GRPC_BRIDGE_METHOD, R"(^cluster\.<NAME>\.grpc\.<NAME>\.((<NAME>)\.))", ".grpc.");
+  // cluster.[<route_target_cluster>.]grpc.[<grpc_service>.](<grpc_method>.)<base_stat>
+  addRegex(GRPC_BRIDGE_METHOD, R"(^cluster(?=\.).*?\.grpc(?=\.).*\.((.*?)\.)\w+?$)", ".grpc.");
 
   // http.[<stat_prefix>.]user_agent.(<user_agent>.)*
   addTokenized(HTTP_USER_AGENT, "http.*.user_agent.$.**");
@@ -145,6 +145,11 @@ void TagNameValues::addRe2(const std::string& name, const std::string& regex,
 
 void TagNameValues::addTokenized(const std::string& name, const std::string& tokens) {
   tokenized_descriptor_vec_.emplace_back(TokenizedDescriptor{name, tokens});
+}
+
+void TagNameValues::addRegex(const std::string& name, const std::string& regex,
+                             const std::string& substr) {
+  descriptor_vec_.emplace_back(Descriptor{name, regex, substr, Regex::Type::StdRegex});
 }
 
 } // namespace Config

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -141,6 +141,7 @@ public:
   }
 
 private:
+  void addRegex(const std::string& name, const std::string& regex, const std::string& substr = "");
   void addRe2(const std::string& name, const std::string& regex, const std::string& substr = "");
 
   // See class doc for TagExtractorTokensImpl in


### PR DESCRIPTION
Signed-off-by: junpengl <ljpeng1001@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
